### PR TITLE
Allow overriding data directory and isolate test data

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,8 +4,13 @@ from typing import List, Dict, Any, Optional
 import pandas as pd
 import yaml, os
 
+# Allow tests (or deployments) to override the default data directory via an
+# environment variable.  In normal operation the CSV/YAML data files live in the
+# repository's ``data`` directory.  During testing we want to use lightweight
+# fixtures instead, so the path can be pointed elsewhere by setting
+# ``SUPPTRACKER_DATA`` before importing this module.
 HERE = os.path.dirname(__file__)
-DATA = os.path.join(HERE, "data")
+DATA = os.environ.get("SUPPTRACKER_DATA", os.path.join(HERE, "data"))
 
 def load_csv(name: str) -> pd.DataFrame:
     p = os.path.join(DATA, name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,38 +2,39 @@ import os
 
 
 def _ensure_test_data():
-    root = os.getcwd()
-    data_dir = os.path.join(root, "data")
-    if not os.path.exists(data_dir):
-        os.makedirs(data_dir, exist_ok=True)
+    """Write minimal CSV/YAML fixtures and point the application to them.
+
+    The real repository ships a much larger dataset under ``data/``.  For the
+    purposes of unit tests we only need a tiny, deterministic subset.  The tests
+    place these files in ``tests/test_data`` and instruct the application to use
+    that directory via the ``SUPPTRACKER_DATA`` environment variable.
+    """
+    root = os.path.dirname(__file__)
+    data_dir = os.path.join(root, "test_data")
+    os.makedirs(data_dir, exist_ok=True)
 
     # compounds.csv
-    comp_csv = os.path.join(data_dir, "compounds.csv")
-    if not os.path.exists(comp_csv):
-        with open(comp_csv, "w", encoding="utf-8") as f:
-            f.write("id,name,synonyms\n")
-            f.write("caffeine,Caffeine,coffee;tea\n")
-            f.write("aspirin,Aspirin,acetylsalicylic acid\n")
+    with open(os.path.join(data_dir, "compounds.csv"), "w", encoding="utf-8") as f:
+        f.write("id,name,synonyms\n")
+        f.write("caffeine,Caffeine,coffee;tea\n")
+        f.write("aspirin,Aspirin,acetylsalicylic acid\n")
 
     # interactions.csv
-    inter_csv = os.path.join(data_dir, "interactions.csv")
-    if not os.path.exists(inter_csv):
-        with open(inter_csv, "w", encoding="utf-8") as f:
-            f.write("compound_a,compound_b,severity,evidence_grade,mechanism_tags,source_ids\n")
-            f.write("caffeine,aspirin,Moderate,B,,source1\n")
+    with open(os.path.join(data_dir, "interactions.csv"), "w", encoding="utf-8") as f:
+        f.write("compound_a,compound_b,severity,evidence_grade,mechanism_tags,source_ids\n")
+        f.write("caffeine,aspirin,Moderate,B,,source1\n")
 
     # sources.csv
-    src_csv = os.path.join(data_dir, "sources.csv")
-    if not os.path.exists(src_csv):
-        with open(src_csv, "w", encoding="utf-8") as f:
-            f.write("id,title\n")
-            f.write("source1,Example source\n")
+    with open(os.path.join(data_dir, "sources.csv"), "w", encoding="utf-8") as f:
+        f.write("id,title\n")
+        f.write("source1,Example source\n")
 
     # risk_rules.yaml
-    rules_yaml = os.path.join(data_dir, "risk_rules.yaml")
-    if not os.path.exists(rules_yaml):
-        with open(rules_yaml, "w", encoding="utf-8") as f:
-            f.write("severity_map:\n  None: 0\n  Mild: 1\n  Moderate: 2\n  Severe: 3\n")
+    with open(os.path.join(data_dir, "risk_rules.yaml"), "w", encoding="utf-8") as f:
+        f.write("severity_map:\n  None: 0\n  Mild: 1\n  Moderate: 2\n  Severe: 3\n")
+
+    # Point the application to the stub data directory before it is imported.
+    os.environ["SUPPTRACKER_DATA"] = data_dir
 
 
 # Ensure data files exist before tests import app


### PR DESCRIPTION
## Summary
- Allow overriding data directory via `SUPPTRACKER_DATA` environment variable
- Add deterministic test fixtures that set `SUPPTRACKER_DATA` to isolated stub data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b99ee5100c8330b1720d5f03bc836e