### PR TITLE
Add httpx dependency for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ uvicorn[standard]==0.23.2
 pandas==2.2.2
 pyyaml==6.0.2
 pytest==7.4.2
+
+httpx==0.24.1


### PR DESCRIPTION
## Summary
- include `httpx` in `requirements.txt` for tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba852d31f8833092290ec931fc3d03