### PR TITLE
Add httpx dependency for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.23.2
 pandas==2.2.2
 pyyaml==6.0.2
 pytest==7.4.2
+httpx==0.24.1


### PR DESCRIPTION
## Summary
- Add httpx to requirements so FastAPI TestClient works

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd994ffffc8330a0b6eda114e839fe