### PR TITLE
Normalize interaction fields and add caffeine dataset entry

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,6 +35,16 @@ def health():
 
 COMPOUNDS_DF = load_csv("compounds.csv")
 INTERACTIONS_DF = load_csv("interactions.csv")
+# Normalise column names so downstream code can rely on a consistent schema
+INTERACTIONS_DF = INTERACTIONS_DF.rename(
+    columns={
+        "a": "compound_a",
+        "b": "compound_b",
+        "mechanism": "mechanism_tags",
+        "evidence": "evidence_grade",
+        "sources": "source_ids",
+    }
+)
 SOURCES_DF = load_csv("sources.csv")
 RULES = load_yaml("risk_rules.yaml")
 

--- a/data/compounds.csv
+++ b/data/compounds.csv
@@ -5,3 +5,4 @@ grapefruit,Grapefruit,"grapefruit juice","Fruit",200,ml,oral
 atorvastatin,Atorvastatin,"Lipitor","Statin",10,mg,oral
 ginkgo,Ginkgo,"Ginkgo biloba","Herb",120,mg,oral
 warfarin,Warfarin,,"Anticoagulant",5,mg,oral
+caffeine,Caffeine,coffee,Stimulant,100,mg,oral


### PR DESCRIPTION
## Summary
- normalize interaction CSV columns so backend uses consistent field names
- add caffeine compound example to dataset

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6b6c5c55883309ac8bd70a7542b9d