### PR TITLE
Add httpx dependency for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ fastapi==0.98.0
 uvicorn[standard]==0.23.2
 pandas==2.2.2
 pyyaml==6.0.2
+httpx==0.27.2
 pytest==7.4.2


### PR DESCRIPTION
## Summary
- add httpx dependency so FastAPI TestClient works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6be16021083308d7ae7d3a4429752