### PR TITLE
Address httpx test warnings and normalize Vite scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
+    "dev": "node scripts/run-vite.js dev",
+    "build": "node scripts/run-vite.js build",
+    "preview": "node scripts/run-vite.js preview"
   },
   "dependencies": {
     "react": "18.2.0",

--- a/scripts/run-vite.js
+++ b/scripts/run-vite.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  console.error('Usage: run-vite <command> [args...]');
+  process.exit(1);
+}
+
+const command = args[0];
+const viteArgs = args.slice(1);
+const env = { ...process.env };
+
+if (env.npm_config_http_proxy) {
+  if (!env.npm_config_proxy) {
+    env.npm_config_proxy = env.npm_config_http_proxy;
+  }
+  delete env.npm_config_http_proxy;
+}
+
+const child = spawn('vite', [command, ...viteArgs], {
+  stdio: 'inherit',
+  env,
+  shell: false,
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code ?? 0);
+  }
+});


### PR DESCRIPTION
## Summary
- switch the API endpoint tests to httpx.AsyncClient with ASGITransport and pin the anyio backend to asyncio, eliminating the deprecated TestClient warning
- add a node-based Vite runner that normalizes the deprecated npm_config_http_proxy variable into npm_config_proxy and use it for dev/build/preview commands

## Testing
- pytest
- env -u npm_config_http_proxy npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8148a817c8330971cee860c937404