### PR TITLE
Handle comma-delimited compound synonyms

### DIFF
--- a/api/risk_api.py
+++ b/api/risk_api.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, Field
 from typing import List, Literal, Dict, Optional
 import os
 import csv
+import re
 
 # Define data models
 class Compound(BaseModel):
@@ -38,7 +39,12 @@ def load_compounds() -> Dict[str, dict]:
     with open(path, encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for row in reader:
-            synonyms = [s.strip() for s in row["synonyms"].split("|")] if row.get("synonyms") else []
+            raw_synonyms = row.get("synonyms") or ""
+            if raw_synonyms:
+                parts = re.split(r"[\|,;]", raw_synonyms)
+                synonyms = [s.strip() for s in parts if s.strip()]
+            else:
+                synonyms = []
             compounds[row["id"]] = {
                 "id": row["id"],
                 "name": row["name"],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,12 +9,29 @@ if ROOT not in sys.path:
 import api.risk_api as app_module
 
 
-def test_resolve_compound():
-    app_module.COMPOUNDS = {
-        "caffeine": {"id": "caffeine", "name": "Caffeine", "synonyms": ["coffee"]}
-    }
+def test_resolve_compound(monkeypatch):
+    monkeypatch.setattr(
+        app_module,
+        "COMPOUNDS",
+        {"caffeine": {"id": "caffeine", "name": "Caffeine", "synonyms": ["coffee"]}},
+    )
     assert app_module.resolve_compound("coffee") == "caffeine"
     assert app_module.resolve_compound("unknown") is None
+
+
+def test_resolve_compound_with_comma_synonyms(tmp_path, monkeypatch):
+    csv_content = (
+        "id,name,synonyms\n"
+        "st_johns_wort,St. John's Wort,\"St. John's Wort, Hypericum\"\n"
+    )
+    (tmp_path / "compounds.csv").write_text(csv_content)
+
+    monkeypatch.setattr(app_module, "DATA_DIR", str(tmp_path))
+    compounds = app_module.load_compounds()
+    monkeypatch.setattr(app_module, "COMPOUNDS", compounds)
+
+    assert compounds["st_johns_wort"]["synonyms"] == ["St. John's Wort", "Hypericum"]
+    assert app_module.resolve_compound("hypericum") == "st_johns_wort"
 
 
 def test_compute_risk_returns_float():


### PR DESCRIPTION
## Summary
- normalize compound synonym parsing to split on pipes, commas, or semicolons and trim whitespace
- add regression coverage confirming resolve_compound handles comma-delimited synonyms

## Testing
- pytest tests/test_core.py

------
https://chatgpt.com/codex/tasks/task_e_68ca0b0c8f748330ad70614b31620bc2