### PR TITLE
Load risk scoring rules from YAML configuration

### DIFF
--- a/tests/test_compute_score.py
+++ b/tests/test_compute_score.py
@@ -5,7 +5,7 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
-from api.risk_api import compute_risk
+import api.risk_api as risk_api
 
 
 def make_inter(severity="Moderate", evidence="B", mechanism=None):
@@ -17,8 +17,74 @@ def make_inter(severity="Moderate", evidence="B", mechanism=None):
 
 
 def test_compute_risk_order():
-    high = compute_risk(make_inter(severity="Severe", evidence="A"))
-    low = compute_risk(make_inter(severity="Mild", evidence="D"))
+    high = risk_api.compute_risk(make_inter(severity="Severe", evidence="A"))
+    low = risk_api.compute_risk(make_inter(severity="Mild", evidence="D"))
     assert high > low
+
+
+def test_load_rules_custom_values(monkeypatch, tmp_path):
+    config_path = tmp_path / "rules.yaml"
+    config_path.write_text(
+        """
+mechanisms:
+  custom:
+    delta: 2.5
+weights:
+  severity: 2.0
+  evidence: 1.5
+  mechanism: 0.5
+map:
+  severity:
+    Severe: 5
+  evidence:
+    A: 1
+""",
+        encoding="utf-8",
+    )
+
+    mechs, weights, severity_map, evidence_map = risk_api.load_rules(str(config_path))
+    assert mechs["custom"] == 2.5
+    assert weights["severity"] == 2.0
+    assert severity_map["Severe"] == 5
+    assert evidence_map["A"] == 1
+
+    monkeypatch.setattr(risk_api, "MECHANISM_DELTAS", mechs)
+    monkeypatch.setattr(risk_api, "WEIGHTS", weights)
+    monkeypatch.setattr(risk_api, "SEVERITY_MAP", severity_map)
+    monkeypatch.setattr(risk_api, "EVIDENCE_MAP", evidence_map)
+
+    score = risk_api.compute_risk(
+        {
+            "severity": "Severe",
+            "evidence": "A",
+            "mechanism": ["custom"],
+        }
+    )
+
+    expected = (
+        severity_map["Severe"] * weights["severity"]
+        + (1 / evidence_map["A"]) * weights["evidence"]
+        + mechs["custom"] * weights["mechanism"]
+    )
+    assert score == round(expected, 2)
+
+
+def test_load_rules_missing_file(tmp_path):
+    missing_path = tmp_path / "missing.yaml"
+    mechs, weights, severity_map, evidence_map = risk_api.load_rules(str(missing_path))
+    assert mechs == risk_api.DEFAULT_MECHANISM_DELTAS
+    assert weights == risk_api.DEFAULT_WEIGHTS
+    assert severity_map == risk_api.DEFAULT_SEVERITY_MAP
+    assert evidence_map == risk_api.DEFAULT_EVIDENCE_MAP
+
+
+def test_load_rules_malformed_file(tmp_path):
+    bad_path = tmp_path / "rules.yaml"
+    bad_path.write_text("mechanisms: [\n", encoding="utf-8")
+    mechs, weights, severity_map, evidence_map = risk_api.load_rules(str(bad_path))
+    assert mechs == risk_api.DEFAULT_MECHANISM_DELTAS
+    assert weights == risk_api.DEFAULT_WEIGHTS
+    assert severity_map == risk_api.DEFAULT_SEVERITY_MAP
+    assert evidence_map == risk_api.DEFAULT_EVIDENCE_MAP
 
 


### PR DESCRIPTION
## Summary
- load rule weights, mechanism deltas, and severity/evidence maps from api/rules.yaml with safe fallbacks
- expose helpers to reload rule configuration and update compute_risk to use the loaded values with sensible defaults
- extend backend tests to cover custom rule loading and ensure API endpoints keep working when the config is missing or malformed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cccf82cc3c833093d8fac9f6e45019