### PR TITLE
Adjust evidence fallback and add regression test

### DIFF
--- a/api/risk_api.py
+++ b/api/risk_api.py
@@ -197,7 +197,8 @@ def compute_risk(inter: dict) -> float:
     """Compute risk score for an interaction."""
 
     severity_score = SEVERITY_MAP.get(inter.get("severity"), 0)
-    evidence_score = EVIDENCE_MAP.get(inter.get("evidence"), DEFAULT_EVIDENCE_MAP["D"])
+    evidence_default = EVIDENCE_MAP.get("D", DEFAULT_EVIDENCE_MAP["D"])
+    evidence_score = EVIDENCE_MAP.get(inter.get("evidence"), evidence_default)
     mech_sum = sum(MECHANISM_DELTAS.get(m, 0.0) for m in inter.get("mechanism", []))
 
     severity_weight = WEIGHTS.get("severity", DEFAULT_WEIGHTS["severity"])


### PR DESCRIPTION
## Summary
- update compute_risk to respect overridden default evidence scores
- add regression test to ensure unknown evidence uses the configured fallback

## Testing
- pytest tests/test_compute_score.py

------
https://chatgpt.com/codex/tasks/task_e_68ccdee4acc083308603c6c0060d8031