### PR TITLE
Add dataset overview and API endpoints for visualized data

### DIFF
--- a/App.css
+++ b/App.css
@@ -38,6 +38,10 @@ body {
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
+.full-width {
+  grid-column: 1 / -1;
+}
+
 .card {
   background: #ffffff;
   border-radius: 18px;
@@ -46,6 +50,11 @@ body {
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.accent-card {
+  background: radial-gradient(circle at top left, #eef2ff, #ffffff);
+  border: 1px solid rgba(99, 102, 241, 0.2);
 }
 
 .card-header h2 {
@@ -171,6 +180,143 @@ button.ghost:hover {
 
 .status-info {
   color: #2563eb;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.stat {
+  background: rgba(79, 70, 229, 0.08);
+  border: 1px solid rgba(79, 70, 229, 0.18);
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.stat-label {
+  font-size: 0.85rem;
+  color: #4338ca;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.stat-value {
+  font-size: 2rem;
+  line-height: 1.1;
+  color: #111827;
+}
+
+.stat-footnote {
+  font-size: 0.85rem;
+  color: #4338ca;
+}
+
+.overview-panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+}
+
+.overview-panel {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 18px;
+  padding: 20px;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.overview-panel h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.interaction-list {
+  margin: 0;
+  padding: 0;
+  list-style: decimal inside;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.interaction-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.interaction-pair {
+  font-size: 1rem;
+}
+
+.interaction-divider {
+  color: #a855f7;
+  font-weight: 700;
+}
+
+.interaction-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.interaction-effect {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.compound-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.compound-name-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.compound-name {
+  font-size: 1rem;
+}
+
+.compound-list dl {
+  margin: 8px 0 0;
+  display: grid;
+  gap: 6px;
+}
+
+.compound-list dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6b7280;
+}
+
+.compound-list dd {
+  margin: 0;
+  color: #1f2937;
+  font-size: 0.95rem;
 }
 
 .pair-inputs {
@@ -330,6 +476,14 @@ button.ghost:hover {
 @media (max-width: 720px) {
   .input-row {
     flex-direction: column;
+  }
+
+  .stat-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .overview-panels {
+    grid-template-columns: 1fr;
   }
 
   .pair-inputs {

--- a/api.ts
+++ b/api.ts
@@ -1,4 +1,10 @@
-import type { Compound, InteractionResponse, StackResponse } from './types'
+import type {
+  Compound,
+  HealthResponse,
+  InteractionResponse,
+  InteractionWithRisk,
+  StackResponse,
+} from './types'
 
 const API_BASE = (() => {
   const envBase = import.meta.env.VITE_API_BASE?.trim()
@@ -51,6 +57,20 @@ export async function searchCompounds(query: string): Promise<Compound[]> {
     `/search?query=${encodeURIComponent(query)}`
   )
   return data.results ?? data.compounds ?? []
+}
+
+export async function fetchHealth(): Promise<HealthResponse> {
+  return request<HealthResponse>('/health')
+}
+
+export async function fetchAllCompounds(): Promise<Compound[]> {
+  const data = await request<{ compounds?: Compound[] }>('/compounds')
+  return data.compounds ?? []
+}
+
+export async function fetchInteractionsList(): Promise<InteractionWithRisk[]> {
+  const data = await request<{ interactions?: InteractionWithRisk[] }>('/interactions')
+  return data.interactions ?? []
 }
 
 export async function fetchInteraction(a: string, b: string): Promise<InteractionResponse> {

--- a/api/risk_api.py
+++ b/api/risk_api.py
@@ -463,6 +463,18 @@ def list_compounds():
     """Get all compounds."""
     return {"compounds": list(COMPOUNDS.values())}
 
+
+@app.get("/api/interactions")
+def list_interactions():
+    """Get all known interactions including computed risk scores."""
+    interactions_with_scores = []
+    for interaction in INTERACTIONS:
+        record = interaction.copy()
+        record["risk_score"] = compute_risk(interaction)
+        interactions_with_scores.append(record)
+
+    return {"interactions": interactions_with_scores}
+
 @app.get("/api/compounds/{compound_id}")
 def get_compound(compound_id: str):
     """Get specific compound by ID."""

--- a/types.ts
+++ b/types.ts
@@ -30,6 +30,10 @@ export interface InteractionRecord {
   sources: string[]
 }
 
+export interface InteractionWithRisk extends InteractionRecord {
+  risk_score: number
+}
+
 export interface InteractionResponse {
   interaction: InteractionRecord
   risk_score: number
@@ -48,4 +52,11 @@ export interface StackInteraction {
 
 export interface StackResponse {
   interactions: StackInteraction[]
+}
+
+export interface HealthResponse {
+  status: string
+  compounds_loaded: number
+  interactions_loaded: number
+  sources_loaded: number
 }


### PR DESCRIPTION
## Summary
- add a dataset overview card to the landing page with live counts, notable interactions, and a compound quick reference
- expose a new `/api/interactions` endpoint plus client helpers so the UI can render complete dataset metadata
- refresh styling to support the richer overview, including new stat tiles and compound detail layouts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de9bfb9b0c8330ada467551018f0d3