### PR TITLE
Expand dataset with cardiometabolic interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ A comprehensive supplement interaction tracking system that helps users make inf
 • 🔌 **Public API**: RESTful API for developers to integrate interaction checking  
 • 🤖 **ChatGPT Ready**: Structured data perfect for AI-powered health assistants  
 • ⚡ **Real-time**: Instant interaction analysis with severity scoring  
-• 📊 **Evidence-based**: Risk assessments based on research data  
+• 📊 **Evidence-based**: Risk assessments based on research data
+• 🧾 **Broader Coverage**: Includes cardiometabolic interactions like omega-3 with warfarin, calcium with levothyroxine, and melatonin with antihypertensives
 
 ## 🚀 Quick Start
 

--- a/data/compounds.csv
+++ b/data/compounds.csv
@@ -5,4 +5,9 @@ grapefruit,Grapefruit,"grapefruit juice","Fruit",200,ml,oral
 atorvastatin,Atorvastatin,"Lipitor","Statin",10,mg,oral
 ginkgo,Ginkgo,"Ginkgo biloba","Herb",120,mg,oral
 warfarin,Warfarin,,"Anticoagulant",5,mg,oral
-caffeine,Caffeine,coffee,Stimulant,100,mg,oral
+caffeine,Caffeine,"coffee","Stimulant",100,mg,oral
+omega_3,Omega-3 Fatty Acids,"fish oil,omega-3 fatty acids,omega 3","Fatty acid",1000,mg,oral
+calcium_carbonate,Calcium Carbonate,"calcium carbonate,calcium supplement,calcium","Mineral",500,mg,oral
+levothyroxine,Levothyroxine,"Synthroid,levothyroxine sodium","Thyroid hormone",75,mcg,oral
+melatonin,Melatonin,"N-acetyl-5-methoxytryptamine","Hormone",5,mg,oral
+nifedipine,Nifedipine,"Adalat,Procardia","Calcium channel blocker",30,mg,oral

--- a/data/interactions.csv
+++ b/data/interactions.csv
@@ -1,7 +1,10 @@
 id,a,b,bidirectional,mechanism,severity,evidence,effect,action,sources
 sjw_sertraline,st_johns_wort,sertraline,true,"serotonergic|CYP3A4_induction","Severe","B","Additive serotonergic effect and CYP3A4 induction; risk of serotonin syndrome","Avoid","source_sjw_ssri"
 grapefruit_atorvastatin,grapefruit,atorvastatin,true,"CYP3A4_inhibition","Moderate","B","Grapefruit inhibits CYP3A4 leading to increased statin levels and risk of myopathy","Monitor","source_grapefruit_statin"
-ginkgo_warfarin,ginkgo,warfarin,true,"Bleeding","Moderate","C","Ginkgo may increase bleeding risk when combined with warfarin","Monitor","source_ginkgo_warfarin"
+ginkgo_warfarin,ginkgo,warfarin,true,"Bleeding|pharmacodynamic","Moderate","C","Ginkgo may increase bleeding risk when combined with warfarin","Monitor","source_ginkgo_warfarin"
 sjw_warfarin,st_johns_wort,warfarin,true,"CYP3A4_induction","Moderate","C","St John's Wort may reduce warfarin levels leading to decreased anticoagulant effect","Monitor","source_sjw_warfarin"
 ginkgo_sertraline,ginkgo,sertraline,true,"serotonergic","Moderate","D","Potential increased serotonergic activity and bleeding risk","Monitor","source_ginkgo_sertraline"
 atorvastatin_warfarin,atorvastatin,warfarin,true,"Bleeding","Moderate","C","Possible increased bleeding risk due to additive anticoagulant effects","Monitor","source_atorvastatin_warfarin"
+omega3_warfarin,omega_3,warfarin,true,"pharmacodynamic|additive","Moderate","B","Omega-3 fatty acids may potentiate warfarin's anticoagulant effect via additive platelet inhibition","Monitor","source_fishoil_warfarin"
+calcium_levothyroxine,calcium_carbonate,levothyroxine,true,"pharmacokinetic","Moderate","B","Calcium carbonate reduces levothyroxine absorption, leading to elevated TSH and reduced efficacy","Separate administration","source_calcium_levothyroxine"
+melatonin_nifedipine,melatonin,nifedipine,true,"pharmacodynamic","Moderate","B","Melatonin can counteract nifedipine's antihypertensive effect, increasing blood pressure","Avoid","source_melatonin_nifedipine"

--- a/data/sources.csv
+++ b/data/sources.csv
@@ -5,3 +5,6 @@ source_ginkgo_warfarin,"Ginkgo biloba and warfarin bleeding risk","https://pubme
 source_sjw_warfarin,"Interaction of St John's Wort with warfarin","https://pubmed.ncbi.nlm.nih.gov/45678/",45678,10.1001/jama.45678,2019-09-10
 source_ginkgo_sertraline,"Potential interactions between Ginkgo and SSRIs","https://pubmed.ncbi.nlm.nih.gov/56789/",56789,10.1177/1111111,2014-01-15
 source_atorvastatin_warfarin,"Statins and warfarin bleeding risk","https://pubmed.ncbi.nlm.nih.gov/67890/",67890,10.1001/jama.67890,2017-11-05
+source_fishoil_warfarin,"Buckley MS et al. Fish oil interaction with warfarin. Ann Pharmacother. 2004;38(1):50-52.","https://pubmed.ncbi.nlm.nih.gov/14742793/",14742793,10.1345/aph.1D007,2004-01-01
+source_calcium_levothyroxine,"Singh N et al. The acute effect of calcium carbonate on the intestinal absorption of levothyroxine. Thyroid. 2001;11(10):967-971.","https://pubmed.ncbi.nlm.nih.gov/11716045/",11716045,10.1089/105072501753211046,2001-10-01
+source_melatonin_nifedipine,"Lusardi P et al. Cardiovascular effects of melatonin in hypertensive patients well controlled by nifedipine: a 24-hour study. Br J Clin Pharmacol. 2000;49(5):423-427.","https://pubmed.ncbi.nlm.nih.gov/10792199/",10792199,10.1046/j.1365-2125.2000.00195.x,2000-05-01


### PR DESCRIPTION
## Summary
- add omega-3 fatty acids, calcium carbonate, levothyroxine, melatonin, and nifedipine compounds with structured dosing metadata
- capture new interaction records for omega-3 + warfarin, calcium + levothyroxine, and melatonin + nifedipine backed by PubMed citations
- highlight the broader cardiometabolic coverage in the feature list

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df47bd62748330a963ab035d39c71b