### PR TITLE
Improve compound lookup to support synonyms and aliases

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,15 @@ def _ensure_test_data():
 
     # compounds.csv
     with open(os.path.join(data_dir, "compounds.csv"), "w", encoding="utf-8") as f:
-        f.write("id,name,synonyms\n")
-        f.write("caffeine,Caffeine,coffee;tea\n")
-        f.write("aspirin,Aspirin,acetylsalicylic acid\n")
+        f.write("id,name,synonyms,aliases,externalIds,referenceUrls\n")
+        f.write(
+            'caffeine,Caffeine,coffee;tea,guarana extract,"{""pubchem"":""2519""}",'
+            '"{""pubchem"":""https://pubchem.ncbi.nlm.nih.gov/compound/2519""}"\n'
+        )
+        f.write(
+            'aspirin,Aspirin,acetylsalicylic acid,ASA,"{""pubchem"":""2244""}",'
+            '"{""pubchem"":""https://pubchem.ncbi.nlm.nih.gov/compound/2244""}"\n'
+        )
 
     # interactions.csv
     with open(os.path.join(data_dir, "interactions.csv"), "w", encoding="utf-8") as f:

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -22,6 +22,7 @@ async def client():
             "id": "caffeine",
             "name": "Caffeine",
             "synonyms": ["coffee", "tea"],
+            "aliases": ["guarana extract"],
             "externalIds": {"pubchem": "2519"},
             "referenceUrls": {
                 "pubchem": "https://pubchem.ncbi.nlm.nih.gov/compound/2519",
@@ -65,6 +66,20 @@ async def test_search_success(client):
     assert resp.status_code == 200
     data = resp.json()
     assert "results" in data
+    assert any(item["id"] == "caffeine" for item in data["results"])
+
+
+async def test_search_matches_synonym(client):
+    resp = await client.get("/api/search", params={"q": "coffee"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(item["id"] == "caffeine" for item in data["results"])
+
+
+async def test_search_matches_alias(client):
+    resp = await client.get("/api/search", params={"q": "guarana"})
+    assert resp.status_code == 200
+    data = resp.json()
     assert any(item["id"] == "caffeine" for item in data["results"])
 
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -37,6 +37,12 @@ async def client():
                 "pubchem": "https://pubchem.ncbi.nlm.nih.gov/compound/2244",
             },
         },
+        "st_johns_wort": {
+            "id": "st_johns_wort",
+            "name": "St. John's Wort",
+            "synonyms": ["Hypericum perforatum"],
+            "aliases": ["St Johns"],
+        },
     }
     app_module.INTERACTIONS = [
         {
@@ -53,6 +59,7 @@ async def client():
         }
     ]
     app_module.SOURCES = {"s1": {"id": "s1", "citation": "Example source"}}
+    app_module.build_compound_indexes()
     transport = httpx.ASGITransport(app=app_module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as async_client:
         yield async_client
@@ -81,6 +88,27 @@ async def test_search_matches_alias(client):
     assert resp.status_code == 200
     data = resp.json()
     assert any(item["id"] == "caffeine" for item in data["results"])
+
+
+async def test_search_partial_match(client):
+    resp = await client.get("/api/search", params={"q": "caff"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["results"][0]["id"] == "caffeine"
+
+
+async def test_search_case_insensitive(client):
+    resp = await client.get("/api/search", params={"q": "ASPIR"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(item["id"] == "aspirin" for item in data["results"])
+
+
+async def test_search_handles_special_characters(client):
+    resp = await client.get("/api/search", params={"q": "st johns"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(item["id"] == "st_johns_wort" for item in data["results"])
 
 
 async def test_search_missing_query_param(client):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -89,7 +89,7 @@ def test_loaders_handle_missing_files(tmp_path, monkeypatch):
 
 
 def test_load_compounds_merges_multiple_sources(tmp_path, monkeypatch):
-    fieldnames = ["id", "name", "synonyms", "externalIds", "referenceUrls"]
+    fieldnames = ["id", "name", "synonyms", "aliases", "externalIds", "referenceUrls"]
     csv_path = tmp_path / "compounds.csv"
     with open(csv_path, "w", newline="", encoding="utf-8") as fh:
         writer = csv.DictWriter(fh, fieldnames=fieldnames)
@@ -99,6 +99,7 @@ def test_load_compounds_merges_multiple_sources(tmp_path, monkeypatch):
                 "id": "creatine",
                 "name": "Creatine",
                 "synonyms": "creatine monohydrate",
+                "aliases": "Creapure",
                 "externalIds": json.dumps({"rxnorm": "123"}),
                 "referenceUrls": "",
             }
@@ -107,7 +108,7 @@ def test_load_compounds_merges_multiple_sources(tmp_path, monkeypatch):
     json_payload = [
         {
             "id": "creatine",
-            "aliases": ["Cr"],
+            "aliases": ["Cr", "Creapure"],
             "externalIds": {"wikidata": "Q173354"},
             "referenceUrls": {"wikipedia": "https://example.com/creatine"},
         },
@@ -127,8 +128,9 @@ def test_load_compounds_merges_multiple_sources(tmp_path, monkeypatch):
     assert set(compounds.keys()) == {"creatine", "magnesium"}
     assert compounds["creatine"]["externalIds"] == {"rxnorm": "123", "wikidata": "Q173354"}
     assert "creatine monohydrate" in compounds["creatine"]["synonyms"]
-    assert "Cr" in compounds["creatine"]["synonyms"]
+    assert compounds["creatine"]["aliases"] == ["Creapure", "Cr"]
     assert compounds["magnesium"]["referenceUrls"]["nih"] == "https://example.com/magnesium"
+    assert compounds["magnesium"].get("aliases", []) == []
 
 
 def test_load_interactions_merges_duplicates(tmp_path, monkeypatch):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,6 +22,24 @@ def test_resolve_compound(monkeypatch):
     assert app_module.resolve_compound("unknown") is None
 
 
+def test_resolve_compound_alias(monkeypatch):
+    monkeypatch.setattr(
+        app_module,
+        "COMPOUNDS",
+        {
+            "caffeine": {
+                "id": "caffeine",
+                "name": "Caffeine",
+                "synonyms": [],
+                "aliases": ["Guarana"],
+            }
+        },
+    )
+    assert app_module.resolve_compound("Guarana") == "caffeine"
+    assert app_module.resolve_compound("guarana") == "caffeine"
+    assert app_module.resolve_compound("CAFFEINE") == "caffeine"
+
+
 def test_resolve_compound_with_comma_synonyms(tmp_path, monkeypatch):
     csv_content = (
         "id,name,synonyms,externalIds,referenceUrls\n"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -18,6 +18,7 @@ def test_resolve_compound(monkeypatch):
         "COMPOUNDS",
         {"caffeine": {"id": "caffeine", "name": "Caffeine", "synonyms": ["coffee"]}},
     )
+    app_module.build_compound_indexes()
     assert app_module.resolve_compound("coffee") == "caffeine"
     assert app_module.resolve_compound("unknown") is None
 
@@ -35,6 +36,7 @@ def test_resolve_compound_alias(monkeypatch):
             }
         },
     )
+    app_module.build_compound_indexes()
     assert app_module.resolve_compound("Guarana") == "caffeine"
     assert app_module.resolve_compound("guarana") == "caffeine"
     assert app_module.resolve_compound("CAFFEINE") == "caffeine"
@@ -50,6 +52,7 @@ def test_resolve_compound_with_comma_synonyms(tmp_path, monkeypatch):
     monkeypatch.setattr(app_module, "DATA_DIR", str(tmp_path))
     compounds = app_module.load_compounds()
     monkeypatch.setattr(app_module, "COMPOUNDS", compounds)
+    app_module.build_compound_indexes()
 
     assert compounds["st_johns_wort"]["synonyms"] == ["St. John's Wort", "Hypericum"]
     assert app_module.resolve_compound("hypericum") == "st_johns_wort"

--- a/tests/test_data/compounds.csv
+++ b/tests/test_data/compounds.csv
@@ -1,3 +1,3 @@
 id,name,synonyms,aliases,externalIds,referenceUrls
 caffeine,Caffeine,coffee;tea,guarana extract,"{""pubchem"":""2519""}","{""pubchem"":""https://pubchem.ncbi.nlm.nih.gov/compound/2519""}"
-aspirin,Aspirin,acetylsalicylic acid,,"{""pubchem"":""2244""}","{""pubchem"":""https://pubchem.ncbi.nlm.nih.gov/compound/2244""}"
+aspirin,Aspirin,acetylsalicylic acid,ASA,"{""pubchem"":""2244""}","{""pubchem"":""https://pubchem.ncbi.nlm.nih.gov/compound/2244""}"

--- a/tests/test_data/compounds.csv
+++ b/tests/test_data/compounds.csv
@@ -1,3 +1,3 @@
-id,name,synonyms,externalIds,referenceUrls
-caffeine,Caffeine,coffee;tea,"{""pubchem"":""2519""}","{""pubchem"":""https://pubchem.ncbi.nlm.nih.gov/compound/2519""}"
-aspirin,Aspirin,acetylsalicylic acid,"{""pubchem"":""2244""}","{""pubchem"":""https://pubchem.ncbi.nlm.nih.gov/compound/2244""}"
+id,name,synonyms,aliases,externalIds,referenceUrls
+caffeine,Caffeine,coffee;tea,guarana extract,"{""pubchem"":""2519""}","{""pubchem"":""https://pubchem.ncbi.nlm.nih.gov/compound/2519""}"
+aspirin,Aspirin,acetylsalicylic acid,,"{""pubchem"":""2244""}","{""pubchem"":""https://pubchem.ncbi.nlm.nih.gov/compound/2244""}"


### PR DESCRIPTION
## Summary
- enhance compound resolution to consider aliases and case-insensitive identifiers
- expand search ranking to match IDs, names, synonyms, and aliases with improved ordering
- extend API tests to cover synonym and alias lookups

## Testing
- pytest
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df5c4705708330917581ca5842d7a2