### PR TITLE
feat(api): expand compound resolution and search coverage

### DIFF
--- a/api/risk_api.py
+++ b/api/risk_api.py
@@ -574,22 +574,61 @@ load_data()
 apply_rules()
 
 # Helper functions
+def _compound_synonyms(compound: Dict[str, Any]) -> List[str]:
+    """Collect synonyms/aliases for a compound in a normalised list."""
+
+    candidates: List[str] = []
+    for field in ("synonyms", "aliases"):
+        values = compound.get(field)
+        for item in _coerce_iterable(values):
+            text = str(item).strip()
+            if text:
+                candidates.append(text)
+    return candidates
+
+
+def _compound_external_ids(compound: Dict[str, Any]) -> List[str]:
+    external_ids = compound.get("externalIds") or {}
+    if not isinstance(external_ids, dict):
+        return []
+    values: List[str] = []
+    for value in external_ids.values():
+        text = str(value).strip()
+        if text:
+            values.append(text)
+    return values
+
+
 def resolve_compound(identifier: str) -> Optional[str]:
-    """Resolve compound by ID, name, or synonym."""
-    if not identifier:
+    """Resolve compound by ID, name, synonym, alias, or external identifier."""
+
+    if identifier is None:
         return None
 
-    if identifier in COMPOUNDS:
-        return identifier
+    identifier_text = str(identifier).strip()
+    if not identifier_text:
+        return None
 
-    identifier_lower = identifier.lower()
-    for comp_id, comp in COMPOUNDS.items():
-        name = str(comp.get("name", "")).lower()
-        if name == identifier_lower:
+    identifier_lower = identifier_text.lower()
+
+    # Direct ID lookup (both exact and case-insensitive)
+    if identifier_text in COMPOUNDS:
+        return identifier_text
+    for comp_id in COMPOUNDS.keys():
+        if comp_id.lower() == identifier_lower:
             return comp_id
 
-        for synonym in _coerce_iterable(comp.get("synonyms") or comp.get("aliases")):
-            if str(synonym).lower() == identifier_lower:
+    for comp_id, comp in COMPOUNDS.items():
+        name = str(comp.get("name", "")).strip()
+        if name and name.lower() == identifier_lower:
+            return comp_id
+
+        for candidate in _compound_synonyms(comp):
+            if candidate.lower() == identifier_lower:
+                return comp_id
+
+        for ext_id in _compound_external_ids(comp):
+            if ext_id.lower() == identifier_lower:
                 return comp_id
 
     return None
@@ -694,28 +733,36 @@ def search(
     query_lower = search_term.lower()
     results = []
     
-    for comp in COMPOUNDS.values():
-        # Check name match
-        name = comp.get("name", "").lower()
-        if query_lower in name:
-            results.append(comp)
-            continue
-        
-        # Check alias matches
-        aliases = comp.get("aliases", [])
-        if isinstance(aliases, list):
-            for alias in aliases:
-                if isinstance(alias, str) and query_lower in alias.lower():
-                    results.append(comp)
-                    break
-    
-    # Sort by relevance (exact matches first)
-    results.sort(key=lambda x: (
-        x.get("name", "").lower() != query_lower,
-        x.get("name", "").lower().find(query_lower)
-    ))
-    
-    return {"results": results[:limit]}
+    ranked: List[Tuple[Tuple[int, int, str], Dict[str, Any]]] = []
+    seen_ids: set[str] = set()
+
+    for comp_id, comp in COMPOUNDS.items():
+        name = str(comp.get("name", ""))
+        name_lower = name.lower()
+        synonyms = _compound_synonyms(comp)
+        synonyms_lower = [s.lower() for s in synonyms]
+        external_ids = [val.lower() for val in _compound_external_ids(comp)]
+        alias_match = query_lower in synonyms_lower
+
+        score: Optional[Tuple[int, int, str]] = None
+
+        if comp_id.lower() == query_lower or name_lower == query_lower:
+            score = (0, len(name), comp_id)
+        elif alias_match or query_lower in external_ids:
+            score = (1, len(name), comp_id)
+        else:
+            partial_tokens = [comp_id.lower(), name_lower] + synonyms_lower + external_ids
+            if any(query_lower in token for token in partial_tokens):
+                score = (2, len(name), comp_id)
+
+        if score and comp_id not in seen_ids:
+            ranked.append((score, comp))
+            seen_ids.add(comp_id)
+
+    ranked.sort(key=lambda item: item[0])
+    results = [comp for _, comp in ranked[:limit]]
+
+    return {"results": results}
 
 @app.get("/api/interaction")
 def interaction(a: str, b: str):

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -68,6 +68,20 @@ async def test_search_success(client):
     assert any(item["id"] == "caffeine" for item in data["results"])
 
 
+async def test_search_matches_synonym(client):
+    resp = await client.get("/api/search", params={"q": "coffee"})
+    assert resp.status_code == 200
+    ids = {item["id"] for item in resp.json().get("results", [])}
+    assert "caffeine" in ids
+
+
+async def test_search_matches_external_id(client):
+    resp = await client.get("/api/search", params={"q": "2519"})
+    assert resp.status_code == 200
+    ids = {item["id"] for item in resp.json().get("results", [])}
+    assert "caffeine" in ids
+
+
 async def test_search_missing_query_param(client):
     resp = await client.get("/api/search")
     assert resp.status_code == 422

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -53,6 +53,28 @@ def test_load_compounds_includes_external_metadata(tmp_path, monkeypatch):
     }
 
 
+def test_resolve_compound_matches_aliases_and_external_ids(monkeypatch):
+    monkeypatch.setattr(
+        app_module,
+        "COMPOUNDS",
+        {
+            "caffeine": {
+                "id": "caffeine",
+                "name": "Caffeine",
+                "synonyms": ["coffee"],
+                "aliases": ["1,3,7-trimethylxanthine"],
+                "externalIds": {"pubchem": "2519"},
+            }
+        },
+    )
+
+    assert app_module.resolve_compound("caffeine") == "caffeine"
+    assert app_module.resolve_compound("Caffeine") == "caffeine"
+    assert app_module.resolve_compound("coffee") == "caffeine"
+    assert app_module.resolve_compound("1,3,7-TRIMETHYLXANTHINE") == "caffeine"
+    assert app_module.resolve_compound("2519") == "caffeine"
+
+
 def test_compute_risk_returns_float():
     inter = {"severity": "Mild", "evidence": "C", "mechanism": []}
     score = app_module.compute_risk(inter)


### PR DESCRIPTION
## Summary
- extend the compound resolver to recognise aliases and external identifiers and reuse shared helpers
- improve the search endpoint ranking while supporting synonym and external-id matches without duplicates
- add API and unit tests covering the new resolution and search behaviours

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e49dbaf6388330981e63e0363f8de7