### PR TITLE
Fix duplicate httpx dependency entry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,3 @@ pandas==2.1.4
 pyyaml==6.0.2
 httpx==0.27.2
 pytest==7.4.2
-
-httpx==0.24.1


### PR DESCRIPTION
## Summary
- remove the duplicated httpx requirement that conflicted with dependency installation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4b6c0e19483308f2c9fed10528859