### PR TITLE
Handle external link strings without labels

### DIFF
--- a/App.test.tsx
+++ b/App.test.tsx
@@ -144,6 +144,22 @@ describe('App external links', () => {
     expect(examineLink).toHaveAttribute('href', 'https://examine.com/supplements/creatine')
   })
 
+  it('renders dataset external links provided as plain URLs', async () => {
+    apiMocks.fetchAllCompounds.mockResolvedValueOnce([
+      {
+        id: 'berberine',
+        name: 'Berberine',
+        synonyms: [],
+        external_links: 'https://example.com/berberine',
+      } as unknown as Compound,
+    ])
+
+    render(<App />)
+
+    const externalLink = await screen.findByRole('link', { name: 'Https://example.com/berberine' })
+    expect(externalLink).toHaveAttribute('href', 'https://example.com/berberine')
+  })
+
   it('renders dataset external links provided as object maps', async () => {
     apiMocks.fetchAllCompounds.mockImplementation(async () => [
       {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -198,13 +198,17 @@ function parseExternalLinksValue(value: unknown): NormalisedExternalLink[] {
       return parseExternalLinksValue(parsed)
     } catch {
       const entries = trimmed
-        .split(';')
+        .split(/[;\n]+/)
         .map((segment) => segment.trim())
         .filter(Boolean)
       const links: NormalisedExternalLink[] = []
       for (const entry of entries) {
         const separator = entry.includes('|') ? '|' : entry.includes(',') ? ',' : null
         if (!separator) {
+          const looksLikeUrl = /^[a-z][a-z0-9+.-]*:\/\//i.test(entry) || entry.startsWith('www.')
+          if (looksLikeUrl) {
+            links.push({ url: entry })
+          }
           continue
         }
         const [rawLabel, rawUrl] = entry.split(separator, 2)


### PR DESCRIPTION
## Summary
- parse newline-delimited or bare string external link values into usable links
- cover plain URL external link strings with a regression test

## Testing
- npm test -- --reporter verbose

------
https://chatgpt.com/codex/tasks/task_e_690c433e66ec8330b074aca8752d3f65