### PR TITLE
Handle case-insensitive duplicates in synonym parser

### DIFF
--- a/backend/synonyms.py
+++ b/backend/synonyms.py
@@ -169,8 +169,11 @@ def parse_synonyms(value: Any) -> List[str]:
             token_clean = token.strip()
             if not token_clean:
                 continue
-            if token_clean not in seen:
-                seen.add(token_clean)
+            # Case-fold to treat aliases with different casing as duplicates while
+            # still preserving the first-seen capitalisation for display.
+            dedupe_key = token_clean.casefold()
+            if dedupe_key not in seen:
+                seen.add(dedupe_key)
                 ordered.append(token_clean)
 
     return ordered


### PR DESCRIPTION
## Summary
- ensure backend synonym parsing deduplicates aliases regardless of letter casing while preserving original formatting

## Testing
- npm test -- --run
- pytest
- pytest tests/test_synonyms_parser.py

------
https://chatgpt.com/codex/tasks/task_e_690cb56570f88330a256c524166faac2