### PR TITLE
Improve stack checker validation and display

### DIFF
--- a/App.test.tsx
+++ b/App.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, within } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import App from './App'
+import { beforeEach, describe, expect, it, test, vi } from 'vitest'
+import App, { parseStackData } from './App'
 import type { Compound, StackResponse } from './types'
 
 const defaultHealthResponse = {
@@ -354,5 +354,36 @@ describe('App external links', () => {
     expect(apiMocks.checkStack).toHaveBeenCalledWith(['Caffeine', 'Ashwagandha'])
     expect(await screen.findByText(/interactions found for caffeine, ashwagandha/i)).toBeInTheDocument()
     expect(screen.getByRole('table')).toBeInTheDocument()
+  })
+})
+
+describe('parseStackData', () => {
+  test('throws error if < 2 compounds', () => {
+    expect(() => parseStackData({}, ['A'])).toThrow(
+      'List at least two compounds to evaluate the stack.',
+    )
+  })
+
+  test('uses resolved_items first', () => {
+    const result = parseStackData({ resolved_items: ['A', 'B'] }, [])
+    expect(result.compounds).toEqual(['A', 'B'])
+  })
+
+  test('uses items if resolved_items missing', () => {
+    const result = parseStackData({ items: ['A', 'B'] }, [])
+    expect(result.compounds).toEqual(['A', 'B'])
+  })
+
+  test('falls back to user input', () => {
+    const result = parseStackData({}, ['A', 'B'])
+    expect(result.compounds).toEqual(['A', 'B'])
+  })
+
+  test('handles null/undefined interactions', () => {
+    const result = parseStackData({ interactions: null }, ['A', 'B'])
+    expect(result.interactions).toBeNull()
+
+    const result2 = parseStackData({}, ['A', 'B'])
+    expect(result2.interactions).toBeNull()
   })
 })

--- a/App.test.tsx
+++ b/App.test.tsx
@@ -293,4 +293,39 @@ describe('App external links', () => {
     expect(apiMocks.checkStack).toHaveBeenCalledWith(['Caffeine', 'Ashwagandha'])
     expect(await screen.findByText(/no interactions detected in caffeine, ashwagandha/i)).toBeInTheDocument()
   })
+
+  it('falls back to stack items when resolved names are missing', async () => {
+    apiMocks.checkStack.mockResolvedValueOnce({
+      interactions: null,
+      items: ['caffeine', 'ashwagandha'],
+    } as unknown as StackResponse)
+
+    render(<App />)
+
+    const textarea = await screen.findByLabelText(/supplement stack list/i)
+    const form = textarea.closest('form') as HTMLFormElement
+    const submitButton = within(form).getByRole('button', { name: /check stack/i })
+    fireEvent.change(textarea, { target: { value: 'Caffeine, Ashwagandha' } })
+    fireEvent.click(submitButton)
+
+    expect(apiMocks.checkStack).toHaveBeenCalledWith(['Caffeine', 'Ashwagandha'])
+    expect(await screen.findByText(/no interactions detected in caffeine, ashwagandha/i)).toBeInTheDocument()
+  })
+
+  it('falls back to submitted names when neither resolved nor items are provided', async () => {
+    apiMocks.checkStack.mockResolvedValueOnce({
+      interactions: undefined,
+    } as unknown as StackResponse)
+
+    render(<App />)
+
+    const textarea = await screen.findByLabelText(/supplement stack list/i)
+    const form = textarea.closest('form') as HTMLFormElement
+    const submitButton = within(form).getByRole('button', { name: /check stack/i })
+    fireEvent.change(textarea, { target: { value: 'Rhodiola, Kava' } })
+    fireEvent.click(submitButton)
+
+    expect(apiMocks.checkStack).toHaveBeenCalledWith(['Rhodiola', 'Kava'])
+    expect(await screen.findByText(/no interactions detected in rhodiola, kava/i)).toBeInTheDocument()
+  })
 })

--- a/App.test.tsx
+++ b/App.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App'
-import type { Compound } from './types'
+import type { Compound, StackResponse } from './types'
 
 const defaultHealthResponse = {
   status: 'healthy',
@@ -264,6 +264,23 @@ describe('App external links', () => {
       interactions: [],
       resolved_items: ['caffeine', 'ashwagandha'],
     })
+
+    render(<App />)
+
+    const textarea = await screen.findByLabelText(/supplement stack list/i)
+    const form = textarea.closest('form') as HTMLFormElement
+    const submitButton = within(form).getByRole('button', { name: /check stack/i })
+    fireEvent.change(textarea, { target: { value: 'Caffeine, Ashwagandha' } })
+    fireEvent.click(submitButton)
+
+    expect(apiMocks.checkStack).toHaveBeenCalledWith(['Caffeine', 'Ashwagandha'])
+    expect(await screen.findByText(/no interactions detected in caffeine, ashwagandha/i)).toBeInTheDocument()
+  })
+
+  it('surfaces normalized stack names when the API omits interaction data', async () => {
+    apiMocks.checkStack.mockResolvedValueOnce({
+      resolved_items: ['caffeine', 'ashwagandha'],
+    } as unknown as StackResponse)
 
     render(<App />)
 

--- a/App.test.tsx
+++ b/App.test.tsx
@@ -258,4 +258,22 @@ describe('App external links', () => {
     expect(apiMocks.checkStack).toHaveBeenCalledWith(['Coffee', 'Aspirin'])
     expect(await screen.findByText(/interactions found for caffeine, aspirin/i)).toBeInTheDocument()
   })
+
+  it('shows resolved stack items even when no interactions are found', async () => {
+    apiMocks.checkStack.mockResolvedValueOnce({
+      interactions: [],
+      resolved_items: ['caffeine', 'ashwagandha'],
+    })
+
+    render(<App />)
+
+    const textarea = await screen.findByLabelText(/supplement stack list/i)
+    const form = textarea.closest('form') as HTMLFormElement
+    const submitButton = within(form).getByRole('button', { name: /check stack/i })
+    fireEvent.change(textarea, { target: { value: 'Caffeine, Ashwagandha' } })
+    fireEvent.click(submitButton)
+
+    expect(apiMocks.checkStack).toHaveBeenCalledWith(['Caffeine', 'Ashwagandha'])
+    expect(await screen.findByText(/no interactions detected in caffeine, ashwagandha/i)).toBeInTheDocument()
+  })
 })

--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,11 @@
-import AppComponent, { DEFAULT_STACK_EXAMPLE as SOURCE_DEFAULT_STACK_EXAMPLE } from './src/App'
+import AppComponent, {
+  DEFAULT_STACK_EXAMPLE as SOURCE_DEFAULT_STACK_EXAMPLE,
+  parseStackData,
+} from './src/App'
 
 export const DEFAULT_STACK_EXAMPLE = 'creatine, caffeine, magnesium'
+
+export { parseStackData }
 
 if (DEFAULT_STACK_EXAMPLE !== SOURCE_DEFAULT_STACK_EXAMPLE) {
   throw new Error('DEFAULT_STACK_EXAMPLE mismatch between entrypoints')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -460,6 +460,16 @@ export default function App(): JSX.Element {
     }, {})
   }, [allCompounds])
 
+  const stackCompoundLabels = useMemo(() => {
+    return stackCompounds.map((compound) => {
+      return (
+        datasetCompoundLookup[compound]?.name ??
+        compoundLookup[compound]?.name ??
+        compound
+      )
+    })
+  }, [stackCompounds, datasetCompoundLookup, compoundLookup])
+
   const topInteractions = useMemo(() => {
     const severityRanking: Record<string, number> = {
       severe: 3,
@@ -936,8 +946,10 @@ export default function App(): JSX.Element {
             <div className="stack-results" aria-live="polite">
               <h3>
                 {stackHasInteractions
-                  ? `Interactions found for ${stackCompounds.join(', ')}`
-                  : 'No interactions detected in this stack'
+                  ? `Interactions found for ${stackCompoundLabels.join(', ')}`
+                  : stackCompoundLabels.length > 0
+                    ? `No interactions detected in ${stackCompoundLabels.join(', ')}`
+                    : 'No interactions detected in this stack'
                 }
               </h3>
               {stackHasInteractions && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -470,6 +470,9 @@ export default function App(): JSX.Element {
     })
   }, [stackCompounds, datasetCompoundLookup, compoundLookup])
 
+  const shouldShowStackResults =
+    stackStatus === 'success' && (stackHasInteractions || stackCompoundLabels.length > 0)
+
   const topInteractions = useMemo(() => {
     const severityRanking: Record<string, number> = {
       severe: 3,
@@ -585,7 +588,9 @@ export default function App(): JSX.Element {
     setStackError(null)
     try {
       const data = await checkStack(compounds)
-      setStackInteractions(data.interactions ?? data.cells ?? [])
+      const interactions = data.interactions ?? data.cells ?? null
+
+      setStackInteractions(interactions)
       setStackCompounds(data.resolved_items ?? data.items ?? compounds)
       setStackStatus('success')
       setStackError(null)
@@ -942,7 +947,7 @@ export default function App(): JSX.Element {
               {stackError}
             </p>
           )}
-          {stackStatus === 'success' && stackInteractions && (
+          {shouldShowStackResults && (
             <div className="stack-results" aria-live="polite">
               <h3>
                 {stackHasInteractions

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -563,11 +563,11 @@ export default function App(): JSX.Element {
   async function handleStackSubmit(event?: FormEvent<HTMLFormElement>) {
     event?.preventDefault()
     const compounds = parseStackInput(stackText)
-    if (compounds.length === 0) {
+    if (compounds.length < 2) {
       setStackStatus('error')
       setStackInteractions(null)
       setStackCompounds([])
-      setStackError('List at least one compound to evaluate the stack.')
+      setStackError('List at least two compounds to evaluate the stack.')
       return
     }
 
@@ -576,7 +576,7 @@ export default function App(): JSX.Element {
     try {
       const data = await checkStack(compounds)
       setStackInteractions(data.interactions ?? data.cells ?? [])
-      setStackCompounds(data.items ?? compounds)
+      setStackCompounds(data.resolved_items ?? data.items ?? compounds)
       setStackStatus('success')
       setStackError(null)
     } catch (error) {


### PR DESCRIPTION
## Summary
- prevent stack checks from running with fewer than two compounds and show a clearer validation error
- display API-resolved stack items in the results summary when available
- add regression coverage for stack validation and resolved item rendering

## Testing
- npx vitest run --reporter basic


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692468f81bfc8330a00c8dad2c3ab5b1)