### PR TITLE
Add PR management templates and automation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## What
+Brief description of the change
+
+## Why
+Problem being solved or feature being added
+
+## Testing
+- [ ] Tests added/updated
+- [ ] Manually tested
+- [ ] CI passes
+
+## Schema Changes
+- [ ] No schema changes
+- [ ] Backend and frontend aligned
+
+## Checklist
+- [ ] PR is <500 lines
+- [ ] Branch is up to date with main
+- [ ] All conversations resolved

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "type: chore"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "type: chore"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "type: chore"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,12 @@
+# Automatically apply labels based on changed files
+"type: docs":
+  - any: ['**/*.md', 'docs/**']
+
+"type: feature":
+  - any: ['frontend/**', 'frontend_dist/**', 'src/**', 'App.*', 'index.html', 'vite.config.ts', 'vite-env.d.ts', 'tsconfig.json']
+
+"type: fix":
+  - any: ['backend/**', 'api/**', 'app.py', 'api.ts', 'data/**']
+
+"type: chore":
+  - any: ['.github/**', 'scripts/**', 'docker/**', 'Dockerfile', 'docker-compose.yml', 'railway.toml']

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,19 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,23 @@
+name: PR Size Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply size labels
+        uses: codelytv/pr-size-labeler@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          xs_max_size: 50
+          s_max_size: 200
+          m_max_size: 500
+          l_max_size: 1000
+          xl_max_size: 2000

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+name: Mark stale issues and PRs
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          days-before-issue-stale: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-label: 'stale'
+          close-pr-label: 'closed-stale'
+          stale-pr-message: |
+            This pull request has been automatically marked as stale due to 30 days of inactivity. Please update, rebase, or comment to keep it active.
+          close-pr-message: |
+            Closing this pull request after a week of inactivity following the stale warning. If the work should continue, please reopen with a fresh rebase and context.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to SuppTracker
+
+Thank you for helping improve SuppTracker! This guide explains how to set up your environment, follow the preferred workflow, and keep pull requests easy to review and merge.
+
+## Local Development
+
+### Prerequisites
+- Python 3.11+
+- Node.js 18+
+- npm and pip
+
+### Backend Setup
+1. Create and activate a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # On Windows use .venv\Scripts\activate
+   ```
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Run the backend test suite:
+   ```bash
+   pytest
+   ```
+
+### Frontend Setup
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run checks locally:
+   ```bash
+   npm test
+   npm run typecheck
+   npm run build
+   ```
+
+## Branch & PR Workflow
+- Keep branches short-lived (<1 week) and rebase frequently against `main`.
+- Use descriptive branch names (e.g., `feature/improve-search-ui`, `fix/api-schema-mismatch`).
+- Aim for atomic PRs under 500 lines of changes. Split large efforts into multiple PRs.
+- Delete feature branches after merging to keep the history tidy.
+
+### PR Preparation Checklist
+Before opening or marking a PR ready for review:
+1. Ensure all automated checks are passing locally (`pytest`, `npm test`, `npm run typecheck`).
+2. Remove debug code, temporary logging, and commented-out blocks.
+3. Confirm backend and frontend contracts are aligned (pay special attention to API response shapes and TypeScript types).
+4. Fill out the pull request template completely, including testing notes and schema alignment.
+5. Resolve or respond to all outstanding review comments before requesting re-review.
+
+### Review Expectations
+- Target review response within 48 hours. If a PR is on hold, clearly document the reason.
+- Prefer small, self-contained PRs to keep review cycles quick.
+- Use GitHub's "Review changes" to batch feedback and approvals.
+
+## Automation & Labels
+- **PR size labels** (`size/XS`–`size/XL`) are applied automatically based on diff size to highlight review effort.
+- **Type labels** (`type: feature`, `type: fix`, `type: docs`, `type: chore`) are auto-applied based on touched files to speed up triage.
+- **Stale handling**: Inactive PRs are marked stale after 30 days and auto-closed a week later. Update or comment to keep them active.
+- **Dependabot** keeps npm, pip, and GitHub Actions dependencies current; please keep its PRs small and merge-ready.
+
+## Code of Conduct
+Be respectful, collaborative, and inclusive. Assume good intent, communicate clearly, and help reviewers by providing context for your changes.


### PR DESCRIPTION
## Summary
- add a pull request template and CONTRIBUTING guide to document expectations and workflows
- introduce automated labeling for PR size and change types plus Dependabot updates
- add stale handling workflow to close inactive pull requests

## Testing
- Not run (documentation and workflow configuration changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693796fa6f9c8330bd6ac5fa4bf37ad3)